### PR TITLE
Switches to use cooldown for badge label

### DIFF
--- a/src/views/Panel/Items/DelayModuleItem.tsx
+++ b/src/views/Panel/Items/DelayModuleItem.tsx
@@ -71,7 +71,7 @@ export const DelayModuleItem = ({ module }: DelayModuleItemProps) => {
         }}
       />
       <Row style={{ alignItems: "center" }}>
-        <Badge>{formatDuration(module.expiration)} delay</Badge>
+        <Badge>{formatDuration(module.cooldown)} delay</Badge>
         <Link
           color="textPrimary"
           noWrap


### PR DESCRIPTION
I could be mistaken, but I think the badge should use the `cooldown` value rather than the `expiration` value