### PR TITLE
Removes modal overlay blur animation and keyframes

### DIFF
--- a/src/views/AddModule/modals/AddModuleModal.tsx
+++ b/src/views/AddModule/modals/AddModuleModal.tsx
@@ -48,9 +48,6 @@ const useStyles = makeStyles((theme) => ({
   },
   backdrop: {
     backdropFilter: "blur(4px)",
-    animationName: "$blur",
-    animationDuration: "500ms",
-    animationTimingFunction: "ease",
   },
   description: {
     marginTop: theme.spacing(1),
@@ -94,14 +91,6 @@ const useStyles = makeStyles((theme) => ({
   warningText: {
     color: "#E0B325",
   },
-  "@keyframes blur": {
-    "0%": {
-      backdropFilter: "blur(0px)",
-    },
-    "100%": {
-      backdropFilter: "blur(4px)",
-    },
-  },
 }));
 
 export const AddModuleModal: React.FC<AddModuleModalProps> = ({
@@ -127,7 +116,6 @@ export const AddModuleModal: React.FC<AddModuleModalProps> = ({
       className={classNames(classes.modal, classes.row, classes.center)}
       BackdropProps={{
         className: classes.backdrop,
-        invisible: true,
       }}
     >
       <Fade in={open}>

--- a/src/views/TransactionBuilder/TransactionBuilder.tsx
+++ b/src/views/TransactionBuilder/TransactionBuilder.tsx
@@ -70,17 +70,6 @@ const useStyles = makeStyles((theme) => ({
   },
   backdrop: {
     backdropFilter: "blur(4px)",
-    animationName: "$blur",
-    animationDuration: "500ms",
-    animationTimingFunction: "ease",
-  },
-  "@keyframes blur": {
-    "0%": {
-      backdropFilter: "blur(0px)",
-    },
-    "100%": {
-      backdropFilter: "blur(4px)",
-    },
   },
   bagIcon: {
     marginLeft: theme.spacing(2),
@@ -158,7 +147,6 @@ export const TransactionBuilder = () => {
       className={classes.modal}
       BackdropProps={{
         className: classes.backdrop,
-        invisible: true,
       }}
     >
       <Fade in={open}>


### PR DESCRIPTION
The blur animation was not functioning correctly, resulting in no background blur on the modal overlay which made for some difficult legibility.

Instead of debugging and fixing the animation bug, I've just removed the blur animation all together. This will be more resilient, but also - there is actually [no way of performantly animating a blur effect](https://developers.google.com/web/updates/2017/10/animated-blur).

The modal animation is currently very quick, so the animation isn't really necessary anyways, however, if we do extend the duration, the fading opacity of the background actually gives the illusion of a blur animation anyways.