### PR TITLE
Update Gnosis Chain RPC endpoint

### DIFF
--- a/src/utils/explorers.ts
+++ b/src/utils/explorers.ts
@@ -43,7 +43,7 @@ export const EXPLORERS_CONFIG: Record<NETWORK, ExplorerData> = {
     safeTransactionApi: "https://safe-transaction.xdai.gnosis.io/",
     verifyContractUrl:
       "https://docs.blockscout.com/for-users/smart-contract-interaction/verifying-a-smart-contract",
-    rpcUrl: "https://rpc.xdaichain.com/",
+    rpcUrl: "https://rpc.gnosischain.com/",
   },
   [NETWORK.POLYGON]: {
     networkExplorerName: "Polygonscan",


### PR DESCRIPTION
The old RPC endpoint seems to be no longer available.
Could be related to a problem reported on Discord: https://discord.com/channels/881881751369175040/884777203332710460/986620010606780417