### PR TITLE
Update `zodiac-ui-components` library version to use new icon

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "react-redux": "^7.2.4",
     "styled-components": "^5.1.1",
     "timeago-react": "^3.0.2",
-    "zodiac-ui-components": "^0.0.29"
+    "zodiac-ui-components": "^0.1.3"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^5.11.4",

--- a/src/views/AddModule/AddModulesView.tsx
+++ b/src/views/AddModule/AddModulesView.tsx
@@ -134,7 +134,7 @@ export const AddModulesView = () => {
         <ModuleButton
           title="Optimistic Governor Module"
           description="Enables on-chain execution of successful Snapshot proposals utilizing UMA's optimistic oracle."
-          icon="reality"
+          icon="optimisticGov"
           onClick={() => setModule(ModuleType.OPTIMISTIC_GOVERNOR)}
         />
 

--- a/src/views/AddModule/modals/OptimisticGovernorModuleModal.tsx
+++ b/src/views/AddModule/modals/OptimisticGovernorModuleModal.tsx
@@ -140,7 +140,7 @@ export const OptimisticGovernorModuleModal = ({
       title="Optimistic Governor Module"
       description="Allows successful Snapshot proposals to 
       execute transactions using UMA's optimistic oracle."
-      icon="tellor"
+      icon="optimisticGov"
       tags={["From Outcome Finance"]}
       onAdd={handleAddOptimisticGovernorModule}
       readMoreLink="https://docs.outcome.finance/optimistic-governance/what-is-the-optimistic-governor"

--- a/yarn.lock
+++ b/yarn.lock
@@ -15383,10 +15383,10 @@ yargs@^16.1.1:
     y18n "^5.0.5"
     yargs-parser "^20.2.2"
 
-zodiac-ui-components@^0.0.29:
-  version "0.0.29"
-  resolved "https://registry.yarnpkg.com/zodiac-ui-components/-/zodiac-ui-components-0.0.29.tgz#85c8242d1e1012cb116efb89337b8d93beb4529f"
-  integrity sha512-aWgOXkbEq8rfryR/92AP4oRPJHM0mvkPkW39SvuGayi//I1o7zwkl7y3sXJDrCRHnuI7EKXarDouOs5lAY2oIw==
+zodiac-ui-components@^0.1.3:
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/zodiac-ui-components/-/zodiac-ui-components-0.1.3.tgz#6959cde2b7049f4ce19fe170ed04b859c6b2bb99"
+  integrity sha512-QwYInaiX35qz6oxNikbNw10fEBPWQzIzz866t8yaRr1TDKG1QdMVQMthoNqpxRi1DpFnL4TmNglBdzq9Ondjhg==
   dependencies:
     "@material-ui/icons" "^4.11.2"
     "@material-ui/lab" "^4.0.0-alpha.60"


### PR DESCRIPTION
## Fix a bug

### Bug Report
Optimistic Governor module did not have a unique Icon.

### Implementation
A unique icon for the Optimistic Governor module was added in [v0.1.3 of `zodiac-ui-components`](https://github.com/gnosis/zodiac-ui-components/releases/tag/v0.1.3)