### PR TITLE
Add chains for the snapshot url

### DIFF
--- a/packages/app/src/views/AddModule/wizards/RealityModule/sections/Review/index.tsx
+++ b/packages/app/src/views/AddModule/wizards/RealityModule/sections/Review/index.tsx
@@ -119,9 +119,14 @@ export const ReviewSection: React.FC<ReviewSectionProps> = ({
   const handleSnapshotSpace = (ens: string) => {
     switch (safe.chainId) {
       case 1:
+      case 56:
+      case 37:
+      case 100:
         setSnapshotSpace(`https://snapshot.org/#/${ens}`)
         break
+
       case 4:
+      case 5:
         setSnapshotSpace(`https://demo.snapshot.org/#/${ens}`)
         break
     }
@@ -177,12 +182,12 @@ export const ReviewSection: React.FC<ReviewSectionProps> = ({
                     <Typography>Template question preview:</Typography>
                     <ZodiacPaper className={classes.paperTemplateContainer}>
                       <Typography>
-                        Did the Snapshot proposal with the id %s in the
-                        {setupData.proposal.ensName} space pass the execution of the array of Module transactions that
-                        have the hash 0x%s and does it meet the requirements of the document referenced in the dao
-                        requirements record at {setupData.proposal.ensName}? The hash is the keccak of the concatenation
-                        of the individual EIP-712 hashes of the Module transactions. If this question was asked before
-                        the corresponding Snapshot proposal was resolved, it should ALWAYS be resolved to INVALID!
+                        Did the Snapshot proposal with the id %s in the {setupData.proposal.ensName} space pass the
+                        execution of the array of Module transactions that have the hash 0x%s and does it meet the
+                        requirements of the document referenced in the dao requirements record at{" "}
+                        {setupData.proposal.ensName}? The hash is the keccak of the concatenation of the individual
+                        EIP-712 hashes of the Module transactions. If this question was asked before the corresponding
+                        Snapshot proposal was resolved, it should ALWAYS be resolved to INVALID!
                       </Typography>
                     </ZodiacPaper>
                   </Grid>


### PR DESCRIPTION
This PR contains an improvement for the review section:

Now we show the proper snapshot space URL depending of the user network 