### PR TITLE
[Optimistic-Governor]: Update goerli bond decimals and OG title

### DIFF
--- a/packages/app/src/components/input/CollateralSelect.tsx
+++ b/packages/app/src/components/input/CollateralSelect.tsx
@@ -31,7 +31,7 @@ export function scaleBondDecimals(collateralAddress: string, bond: string): numb
     case "0xc778417E063141139Fce010982780140Aa0cD5Ab":
       return Number(bond) * Math.pow(10, 18);
     case "0x07865c6E87B9F70255377e024ace6630C1Eaa37F":
-      return Number(bond) * Math.pow(10, 18);
+      return Number(bond) * Math.pow(10, 6);
     case "0xB4FBF271143F4FBf7B91A5ded31805e42b2208d6":
       return Number(bond) * Math.pow(10, 18);
   }

--- a/packages/app/src/store/modules/models.ts
+++ b/packages/app/src/store/modules/models.ts
@@ -27,7 +27,7 @@ export const MODULE_TYPES: Record<string, ModuleType> = {
 
 export const MODULE_NAMES: Record<ModuleType, string> = {
   [ModuleType.TELLOR]: "Tellor Module",
-  [ModuleType.OPTIMISTIC_GOVERNOR]: "Optimistic Governor Module",
+  [ModuleType.OPTIMISTIC_GOVERNOR]: "UMA Optimistic Governor Module",
   [ModuleType.REALITY_ERC20]: "Reality Module",
   [ModuleType.REALITY_ETH]: "Reality Module",
   [ModuleType.UNKNOWN]: "Unknown Module",

--- a/packages/app/src/views/AddModule/index.tsx
+++ b/packages/app/src/views/AddModule/index.tsx
@@ -129,7 +129,7 @@ export const AddModulesView = () => {
         />
 
         <ModuleButton
-          title="Optimistic Governor Module"
+          title="UMA Optimistic Governor Module"
           description="Enables on-chain execution of successful Snapshot proposals utilizing UMA's optimistic oracle."
           icon="optimisticGov"
           onClick={() => setModule(ModuleType.OPTIMISTIC_GOVERNOR)}

--- a/packages/app/src/views/AddModule/wizards/OptimisticGovernorModule/OptimisticGovernorModuleModal.tsx
+++ b/packages/app/src/views/AddModule/wizards/OptimisticGovernorModule/OptimisticGovernorModuleModal.tsx
@@ -118,8 +118,8 @@ export const OptimisticGovernorModuleModal = ({ open, onClose, onSubmit }: Optim
     <AddModuleModal
       open={open}
       onClose={onClose}
-      title="Optimistic Governor Module"
-      description="Allows successful Snapshot proposals to
+      title="UMA Optimistic Governor Module"
+      description="Allows successful Snapshot proposals to 
       execute transactions using UMA's optimistic oracle."
       icon="optimisticGov"
       tags={["From Outcome Finance"]}


### PR DESCRIPTION
This PR fixes an issue with the scaling of USDC on Goerli by changing the decimals from 18 to 6.

This PR also updates the naming of the optimistic governor module to avoid confusion with the OZ/Compound Governor.
