### PR TITLE
Update Vercel deployment and environment variable for Github Workflows

### DIFF
--- a/.github/workflows/dev-cd.yaml
+++ b/.github/workflows/dev-cd.yaml
@@ -8,7 +8,7 @@ env:
   REACT_APP_ETHERSCAN_KEY: ${{ secrets.REACT_APP_ETHERSCAN_KEY }}
   REACT_APP_INFURA_ID: ${{ secrets.REACT_APP_INFURA_ID }}
   REACT_APP_MULTI_SEND_CONTRACT: "0xA238CBeb142c10Ef7Ad8442C6D1f9E89e07e7761"
-  REACT_APP_BACKEND_API_URL: "http://api.dev.zodiac.gnosisguild.org/api"
+  REACT_APP_BACKEND_API_URL: "https://api.dev.zodiac.gnosisguild.org/api"
 
 jobs:
   deploy:

--- a/.github/workflows/dev-cd.yaml
+++ b/.github/workflows/dev-cd.yaml
@@ -8,7 +8,7 @@ env:
   REACT_APP_ETHERSCAN_KEY: ${{ secrets.REACT_APP_ETHERSCAN_KEY }}
   REACT_APP_INFURA_ID: ${{ secrets.REACT_APP_INFURA_ID }}
   REACT_APP_MULTI_SEND_CONTRACT: "0xA238CBeb142c10Ef7Ad8442C6D1f9E89e07e7761"
-  REACT_APP_BACKEND_API_URL: "https://zodiac-safe-8vkl4ntne-gnosis-guild.vercel.app/api"
+  REACT_APP_BACKEND_API_URL: "http://api.dev.zodiac.gnosisguild.org/api"
 
 jobs:
   deploy:

--- a/.github/workflows/dev-cd.yaml
+++ b/.github/workflows/dev-cd.yaml
@@ -8,6 +8,7 @@ env:
   REACT_APP_ETHERSCAN_KEY: ${{ secrets.REACT_APP_ETHERSCAN_KEY }}
   REACT_APP_INFURA_ID: ${{ secrets.REACT_APP_INFURA_ID }}
   REACT_APP_MULTI_SEND_CONTRACT: "0xA238CBeb142c10Ef7Ad8442C6D1f9E89e07e7761"
+  REACT_APP_BACKEND_API_URL: "https://zodiac-safe-8vkl4ntne-gnosis-guild.vercel.app/api"
 
 jobs:
   deploy:

--- a/.github/workflows/prod-release-deploy.yaml
+++ b/.github/workflows/prod-release-deploy.yaml
@@ -8,6 +8,7 @@ env:
   REACT_APP_ETHERSCAN_KEY: ${{ secrets.REACT_APP_ETHERSCAN_KEY }}
   REACT_APP_INFURA_ID: ${{ secrets.REACT_APP_INFURA_ID }}
   REACT_APP_MULTI_SEND_CONTRACT: "0xA238CBeb142c10Ef7Ad8442C6D1f9E89e07e7761"
+  REACT_APP_BACKEND_API_URL: "http://api.zodiac.gnosisguild.org//api"
 
 jobs:
   deploy:
@@ -80,3 +81,14 @@ jobs:
         with:
           branch: gh-pages # The branch the action should deploy to.
           folder: packages/app/build
+
+      # Deploys a production instance of the backend api to vercel
+      - name: Deploy to Vercel Action
+        uses: BetaHuhn/deploy-to-vercel-action@v1
+        with:
+          GITHUB_TOKEN: ${{ github.token }}
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+          VERCEL_SCOPE: "gnosis-guild"
+          PRODUCTION: true

--- a/.github/workflows/prod-release-deploy.yaml
+++ b/.github/workflows/prod-release-deploy.yaml
@@ -8,7 +8,7 @@ env:
   REACT_APP_ETHERSCAN_KEY: ${{ secrets.REACT_APP_ETHERSCAN_KEY }}
   REACT_APP_INFURA_ID: ${{ secrets.REACT_APP_INFURA_ID }}
   REACT_APP_MULTI_SEND_CONTRACT: "0xA238CBeb142c10Ef7Ad8442C6D1f9E89e07e7761"
-  REACT_APP_BACKEND_API_URL: "http://api.zodiac.gnosisguild.org//api"
+  REACT_APP_BACKEND_API_URL: "https://api.zodiac.gnosisguild.org//api"
 
 jobs:
   deploy:

--- a/.github/workflows/prod-release-deploy.yaml
+++ b/.github/workflows/prod-release-deploy.yaml
@@ -8,7 +8,7 @@ env:
   REACT_APP_ETHERSCAN_KEY: ${{ secrets.REACT_APP_ETHERSCAN_KEY }}
   REACT_APP_INFURA_ID: ${{ secrets.REACT_APP_INFURA_ID }}
   REACT_APP_MULTI_SEND_CONTRACT: "0xA238CBeb142c10Ef7Ad8442C6D1f9E89e07e7761"
-  REACT_APP_BACKEND_API_URL: "https://api.zodiac.gnosisguild.org//api"
+  REACT_APP_BACKEND_API_URL: "https://api.zodiac.gnosisguild.org/api"
 
 jobs:
   deploy:


### PR DESCRIPTION
Fixes #126

@samepant: I see that the Vercel deployment says the deployment environment is production for updates to master. Is it possible to create a dev environment where it publishes from master and a separate production environment only for new releases?
If we get this updated, then we need to add/update the `REACT_APP_BACKEND_API_URL` variable in the GitHub workflows.