### PR TITLE
Fix CI build error: JavaScript heap out of memory

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -51,7 +51,7 @@
   },
   "scripts": {
     "start": "react-app-rewired start",
-    "build": "react-app-rewired build",
+    "build": "react-app-rewired --max_old_space_size=4096 build",
     "test": "react-scripts test --watchAll=false",
     "eject": "react-scripts eject"
   },


### PR DESCRIPTION
Fix: `FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory`