### PR TITLE
Use vercel cli to build backend

### DIFF
--- a/.github/workflows/prod-release-deploy.yaml
+++ b/.github/workflows/prod-release-deploy.yaml
@@ -83,12 +83,11 @@ jobs:
           folder: packages/app/build
 
       # Deploys a production instance of the backend api to vercel
-      - name: Deploy to Vercel Action
-        uses: BetaHuhn/deploy-to-vercel-action@v1
-        with:
-          GITHUB_TOKEN: ${{ github.token }}
-          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
-          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
-          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
-          VERCEL_SCOPE: "gnosis-guild"
-          PRODUCTION: true
+      - name: Install Vercel CLI
+        run: npm install --global vercel@latest
+      - name: Pull Vercel Environment Information
+        run: vercel pull --yes --environment=production --scope gnosis-guild --token=${{ secrets.VERCEL_TOKEN }}
+      - name: Build Project Artifacts
+        run: vercel build --prod --token=${{ secrets.VERCEL_TOKEN }}
+      - name: Deploy Project Artifacts to Vercel
+        run: vercel deploy --prebuilt --prod --token=${{ secrets.VERCEL_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ yarn-error.log*
 .idea/
 .vscode/
 test.http
+.vercel


### PR DESCRIPTION
The `BetaHuhn/deploy-to-vercel-action@v1` action package was getting hung during our release deployment action. I believe this is because we don't have a `build` script in our `package.json` (relying instead on vercel to do the building directly). Also it was originally created before vercel had better support for its CLI tool.

I changed the vercel deployment portion of the action to use the CLI directly.