### PR TITLE
Remove a too-strict check for validating tokens

### DIFF
--- a/packages/app/src/views/AddModule/wizards/OzGovernor/service/tokenValidation.ts
+++ b/packages/app/src/views/AddModule/wizards/OzGovernor/service/tokenValidation.ts
@@ -22,7 +22,6 @@ export const isVotesCompilable =
         tokenContract.getPastVotes(RANDOM_VALID_ADDRESS, RANDOM_BLOCK_NUMBER),
         tokenContract.getPastTotalSupply(RANDOM_BLOCK_NUMBER),
         tokenContract.callStatic.delegates(RANDOM_VALID_ADDRESS),
-        tokenContract.callStatic.delegate(RANDOM_VALID_ADDRESS),
       ])
       // eslint-disable-next-line
       tokenContract.functions["delegateBySig"].name


### PR DESCRIPTION
I experimented with adding an alternative check but ended up just removing the check due to complexity when checking for the `delegate` function in cases when the token contract is a proxy.
Also, I don't think the check brings much more value than the checks already in place.