### PR TITLE
fix: outdated space schema validation

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -13,7 +13,7 @@
     "@material-ui/icons": "^4.11.3",
     "@material-ui/lab": "^4.0.0-alpha.61",
     "@reduxjs/toolkit": "^1.6.0",
-    "@snapshot-labs/snapshot.js": "^0.4.28",
+    "@snapshot-labs/snapshot.js": "^0.4.68",
     "async-retry": "^1.3.1",
     "classnames": "^2.3.1",
     "ethcall": "^3.4.1",

--- a/packages/app/yarn.lock
+++ b/packages/app/yarn.lock
@@ -2824,13 +2824,14 @@
   resolved "https://registry.npmjs.org/@sindresorhus/is/-/is-0.14.0.tgz"
   integrity sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ==
 
-"@snapshot-labs/snapshot.js@^0.4.28":
-  version "0.4.28"
-  resolved "https://registry.npmjs.org/@snapshot-labs/snapshot.js/-/snapshot.js-0.4.28.tgz"
-  integrity sha512-zP/XtR6gzoF5KjD8q9PdlN7HMQGC1yX9pT1hK185xqfdwB57Ut+Jk3Sk7Sr6bRygSSTlSSyg12zZ1EdHwZMGyw==
+"@snapshot-labs/snapshot.js@^0.4.68":
+  version "0.4.68"
+  resolved "https://registry.yarnpkg.com/@snapshot-labs/snapshot.js/-/snapshot.js-0.4.68.tgz#01b1da4a47d2a8f27a9d662e8768a457e46c8024"
+  integrity sha512-RVPo4iNnnt51nY7A0mVLSl3HGzsEmAQlH/ZtbI3TQtpCjI0pNG/VVvyvVG3/ue9/xgo5U6OzirD8DKcPT51fYQ==
   dependencies:
     "@ensdomains/eth-ens-namehash" "^2.0.15"
     "@ethersproject/abi" "^5.6.4"
+    "@ethersproject/address" "^5.6.1"
     "@ethersproject/bytes" "^5.6.1"
     "@ethersproject/contracts" "^5.6.2"
     "@ethersproject/hash" "^5.6.1"


### PR DESCRIPTION
## Fix a bug

### Bug Report

fixes #194

### Implementation

Updates snapshot.js, which should use the latest schema.

### Additional Context

snapshot.js has been considering `moderators` as part of the json schema since v0.4.62 https://github.com/snapshot-labs/snapshot.js/commit/f8e2d1d8ca264f4e1e9d9c653a9af404fd4adba1