### PR TITLE
Add helpful error message regarding ad blockers

### DIFF
--- a/packages/app/src/views/AddModule/wizards/RealityModule/index.tsx
+++ b/packages/app/src/views/AddModule/wizards/RealityModule/index.tsx
@@ -160,7 +160,16 @@ export const RealityModule: React.FC = () => {
 
     const statusLogger = (currentStatus: string, error?: Error) => {
       if (error != null) {
-        logger.push({ error: true, msg: error.toString() })
+        if (error.name === "OpenError") {
+          logger.push({
+            error: true,
+            msg:
+              error.toString() +
+              `This error can be caused by add/track blockers. Please disable any blockers (for instance, the Brave Shield) and try again.`,
+          })
+        } else {
+          logger.push({ error: true, msg: error.toString() })
+        }
         throw error
       } else {
         logger.push({ error: false, msg: currentStatus })


### PR DESCRIPTION
When the Reality Module setup fails because of an error often caused by ad blockers, we ask the user to disable the blocker and try again.

Closes #199