### PR TITLE
feat: restrict osnap quorum to uint256

### DIFF
--- a/packages/app/src/views/AddModule/wizards/OptimisticGovernorModule/OptimisticGovernorModuleModal.tsx
+++ b/packages/app/src/views/AddModule/wizards/OptimisticGovernorModule/OptimisticGovernorModuleModal.tsx
@@ -203,7 +203,7 @@ export const OptimisticGovernorModuleModal = ({
         </Grid>
         <Grid item xs={6}>
           <ParamInput
-            param={ParamType.from("string")}
+            param={ParamType.from("uint256")}
             color="secondary"
             value={params.votingQuorum}
             label="Voting Quorum"


### PR DESCRIPTION

## Fix a bug

### Bug Report

oSnap module can be deployed with rules containing arbitrary string for vote quorum. This can cause ambiguity when verifying proposal if the quorum value was not number.

### Implementation

Restricts votingQuorum param to accept only uint256 when deploying new oSnap module.
