### PR TITLE
Stop notifying when Proposals are Submitted, only notify when Answers are submitted

### DIFF
--- a/packages/backend/api/monitoring/notification.ts
+++ b/packages/backend/api/monitoring/notification.ts
@@ -68,7 +68,6 @@ export default async (request: VercelRequest, response: VercelResponse) => {
 
     const sentinelCreationResponds = await createSentinel(
       sentinelClient,
-      notificationChannelIds,
       network,
       realityModuleAddress,
       autotaskId,

--- a/packages/backend/lib/defender/autotasks/on_new_question_from_module.ts
+++ b/packages/backend/lib/defender/autotasks/on_new_question_from_module.ts
@@ -93,6 +93,10 @@ exports.handler = async function (event) {
       },
     ],
     notificationChannels: notificationChannels,
+    alertThreshold: {
+      amount: 2,
+      windowSeconds: 300,
+    },
   }
 
   return client.create(requestParameters)

--- a/packages/backend/lib/defender/index.ts
+++ b/packages/backend/lib/defender/index.ts
@@ -38,7 +38,6 @@ export const setupNewNotificationChannel = async (
 
 export const createSentinel = async (
   client: SentinelClient,
-  notificationChannels: string[],
   network: Network,
   realityModuleAddress: string,
   autotaskId: string,
@@ -74,7 +73,7 @@ export const createSentinel = async (
       },
     ],
     autotaskTrigger: autotaskId,
-    notificationChannels: notificationChannels,
+    notificationChannels: [],
   }
 
   const sentinel = await client.create(requestParameters)


### PR DESCRIPTION
Reality Module allows anyone to propose a hash authorizing many transactions to be submitted. Other than gas, there is no cost involved with this action.

The module will only accept proposals whose linked reality.eth question is answered as correctly voted in Snapshot. In order to do this, a bond needs to be placed, which will be considered the intended cost to attack the governor.

The way notifications are currently setup, notifications are launched whenever the hash is proposed. This is an action that any actor could do, and do it for free, so it leaves the door for anyone to pollute the notification system.

### Making sense of current setup

1. Notification Channels are created, with `notificationChannelIds` returned
2. An "Autotask" is created, whose job is deploying a new Sentinel watching the Reality.eth contract with the required `questionId`, whenever a proposal happens. It receives the `notificationChannelIds`.
3. The "master" Sentinel is created, linked to the autotask above, and it also receives the `notificationChannelIds`.

### Assessing original intention

It appears that the purpose of watching for the `LogNewAnswer` event was, to notify when the most important action happened, that is, whenever a bond is placed to assert a hash is correct.

### Issues

There are two problems:

1. Any malicious actor can pollute the notification space of a DAO by proposing hashes, free of charge.
2. There are default `alertThreshold`s that limit the amount of notifications that can be generated per window of time, and they might be too low.

In practice, this 2nd point meant that, when testing and creating a proposal and placing the first bond immediately, you only got a notification for the first action.

### Solution

This PR makes `ProposalQuestionCreated` stop notifying, and it adds an explicitly lax `alertThreshold` in the `LogNewAnswer` autotask (notify up to two times every 5min window)

### Links

`alertThreshold` https://docs.openzeppelin.com/defender/sentinel-api-reference#create-endpoint