### PR TITLE
feat: decrease collisions notification channels

### DIFF
--- a/packages/backend/api/monitoring/notification.ts
+++ b/packages/backend/api/monitoring/notification.ts
@@ -51,7 +51,13 @@ export default async (request: VercelRequest, response: VercelResponse) => {
     const notificationChannelIds = await Promise.all(
       notificationChannels.map(
         async ({ channel, config }) =>
-          await setupNewNotificationChannel(sentinelClient, channel, config),
+          await setupNewNotificationChannel(
+            sentinelClient,
+            channel,
+            config,
+            realityModuleAddress,
+            network,
+          ),
       ),
     )
 

--- a/packages/backend/lib/defender/index.ts
+++ b/packages/backend/lib/defender/index.ts
@@ -21,10 +21,12 @@ export const setupNewNotificationChannel = async (
   client: SentinelClient,
   channel: NotificationType,
   config: any,
+  realityModuleAddress: string,
+  network: Network,
 ) => {
   const notificationChannel = await client.createNotificationChannel({
     type: channel,
-    name: `ZodiacRealityModuleNotification-${channel}`,
+    name: `ZodiacRealityModuleNotification-${network}:${realityModuleAddress}-${channel}`,
     config,
     paused: false,
   })


### PR DESCRIPTION
this PR could be ignored, since the ids of notification channels are generated independently of the name.
only useful for users that are tracking multiple modules.

screenshot of the motivation of this PR, browsing my Open Zeppelin Sentinel account:
<img width="394" alt="image" src="https://github.com/gnosis/zodiac-safe-app/assets/40367733/4dd9a1a1-a6d3-45fe-9b6b-58ffa07c5af9">
