### PR TITLE
Add Kleros in goerli

### DIFF
--- a/packages/app/src/components/input/ArbitratorSelect.tsx
+++ b/packages/app/src/components/input/ArbitratorSelect.tsx
@@ -15,6 +15,7 @@ export const arbitratorOptions = {
 // List of chain IDs where Kleros is available.
 export const klerosAvailability: number[] = [
   NETWORK.MAINNET,
+  NETWORK.GOERLI,
   NETWORK.GNOSIS_CHAIN,
   NETWORK.POLYGON,
 ]

--- a/packages/app/src/services/index.ts
+++ b/packages/app/src/services/index.ts
@@ -182,6 +182,8 @@ export function getKlerosAddress(chainId: number): string {
   switch (chainId) {
     case NETWORK.MAINNET:
       return "0xf72cfd1b34a91a64f9a98537fe63fbab7530adca"
+    case NETWORK.GOERLI:
+      return "0xba08deb3f07a9c55052777fed84a86be8e5ebc1c"
     case NETWORK.GNOSIS_CHAIN:
       return "0x29f39de98d750eb77b5fafb31b2837f079fce222"
     case NETWORK.POLYGON:

--- a/packages/backend/api/monitoring/notification.ts
+++ b/packages/backend/api/monitoring/notification.ts
@@ -68,7 +68,6 @@ export default async (request: VercelRequest, response: VercelResponse) => {
 
     const sentinelCreationResponds = await createSentinel(
       sentinelClient,
-      notificationChannelIds,
       network,
       realityModuleAddress,
       autotaskId,

--- a/packages/backend/lib/defender/autotasks/on_new_question_from_module.ts
+++ b/packages/backend/lib/defender/autotasks/on_new_question_from_module.ts
@@ -93,6 +93,10 @@ exports.handler = async function (event) {
       },
     ],
     notificationChannels: notificationChannels,
+    alertThreshold: {
+      amount: 2,
+      windowSeconds: 300,
+    },
   }
 
   return client.create(requestParameters)

--- a/packages/backend/lib/defender/index.ts
+++ b/packages/backend/lib/defender/index.ts
@@ -38,7 +38,6 @@ export const setupNewNotificationChannel = async (
 
 export const createSentinel = async (
   client: SentinelClient,
-  notificationChannels: string[],
   network: Network,
   realityModuleAddress: string,
   autotaskId: string,
@@ -74,7 +73,7 @@ export const createSentinel = async (
       },
     ],
     autotaskTrigger: autotaskId,
-    notificationChannels: notificationChannels,
+    notificationChannels: [],
   }
 
   const sentinel = await client.create(requestParameters)


### PR DESCRIPTION
Makes Kleros available in Goerli, so now Kleros Snapshot displays on Goerli, and can be tested on an actual testnet