### PR TITLE
feat: add kleros to goerli

### DIFF
--- a/packages/app/src/components/input/ArbitratorSelect.tsx
+++ b/packages/app/src/components/input/ArbitratorSelect.tsx
@@ -15,6 +15,7 @@ export const arbitratorOptions = {
 // List of chain IDs where Kleros is available.
 export const klerosAvailability: number[] = [
   NETWORK.MAINNET,
+  NETWORK.GOERLI,
   NETWORK.GNOSIS_CHAIN,
   NETWORK.POLYGON,
 ]

--- a/packages/app/src/services/index.ts
+++ b/packages/app/src/services/index.ts
@@ -182,6 +182,8 @@ export function getKlerosAddress(chainId: number): string {
   switch (chainId) {
     case NETWORK.MAINNET:
       return "0xf72cfd1b34a91a64f9a98537fe63fbab7530adca"
+    case NETWORK.GOERLI:
+      return "0xba08deb3f07a9c55052777fed84a86be8e5ebc1c"
     case NETWORK.GNOSIS_CHAIN:
       return "0x29f39de98d750eb77b5fafb31b2837f079fce222"
     case NETWORK.POLYGON:


### PR DESCRIPTION
Kleros will become available in Goerli for testing. Makes the Kleros Snapshot Module display on Goerli, and allows picking Kleros Arbitrator on the regular wizard on Goerli