### PR TITLE
fix: autotask abi is now valid JSON

### DIFF
--- a/packages/backend/lib/defender/autotasks/on_new_question_from_module.ts
+++ b/packages/backend/lib/defender/autotasks/on_new_question_from_module.ts
@@ -36,53 +36,53 @@ exports.handler = async function (event) {
     paused: false,
     abi: \`[
   {
-    anonymous: false,
-    inputs: [
+    "anonymous": false,
+    "inputs": [
       {
-        indexed: false,
-        internalType: "bytes32",
-        name: "answer",
-        type: "bytes32",
+        "indexed": false,
+        "internalType": "bytes32",
+        "name": "answer",
+        "type": "bytes32"
       },
       {
-        indexed: true,
-        internalType: "bytes32",
-        name: "question_id",
-        type: "bytes32",
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "question_id",
+        "type": "bytes32"
       },
       {
-        indexed: false,
-        internalType: "bytes32",
-        name: "history_hash",
-        type: "bytes32",
+        "indexed": false,
+        "internalType": "bytes32",
+        "name": "history_hash",
+        "type": "bytes32"
       },
       {
-        indexed: true,
-        internalType: "address",
-        name: "user",
-        type: "address",
+        "indexed": true,
+        "internalType": "address",
+        "name": "user",
+        "type": "address"
       },
       {
-        indexed: false,
-        internalType: "uint256",
-        name: "bond",
-        type: "uint256",
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "bond",
+        "type": "uint256"
       },
       {
-        indexed: false,
-        internalType: "uint256",
-        name: "ts",
-        type: "uint256",
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "ts",
+        "type": "uint256"
       },
       {
-        indexed: false,
-        internalType: "bool",
-        name: "is_commitment",
-        type: "bool",
-      },
+        "indexed": false,
+        "internalType": "bool",
+        "name": "is_commitment",
+        "type": "bool"
+      }
     ],
-    name: "LogNewAnswer",
-    type: "event",
+    "name": "LogNewAnswer",
+    "type": "event"
   }
 ]\`,
     eventConditions: [


### PR DESCRIPTION
OpenZeppelin Defender complains that the ABI that the Sentinel has received when created by the Autotask is not valid

![image](https://github.com/gnosis/zodiac-safe-app/assets/40367733/b097a27e-3c7c-4e44-b9b9-17560c38b494)

Turning it into valid JSON seems to solve the issue. That is, double quotes on properties and no trailing commas.

![image](https://github.com/gnosis/zodiac-safe-app/assets/40367733/2053c340-5b8a-4c31-87eb-a08e4bcdfc5d)
