### PR TITLE
fix: remove alert threshold

### DIFF
--- a/packages/backend/lib/defender/autotasks/on_new_question_from_module.ts
+++ b/packages/backend/lib/defender/autotasks/on_new_question_from_module.ts
@@ -93,10 +93,6 @@ exports.handler = async function (event) {
       },
     ],
     notificationChannels: notificationChannels,
-    alertThreshold: {
-      amount: 2,
-      windowSeconds: 300,
-    },
   }
 
   return client.create(requestParameters)


### PR DESCRIPTION
alert threshold means:
"notify when 2 triggers in time window"
not
"notify up to 2 times in time window"
so it's been removed