### PR TITLE
fix: chatID -> chatId for telegram

### DIFF
--- a/packages/app/src/views/AddModule/wizards/KlerosRealityModule/KlerosRealityModuleModal.tsx
+++ b/packages/app/src/views/AddModule/wizards/KlerosRealityModule/KlerosRealityModuleModal.tsx
@@ -435,7 +435,7 @@ export const KlerosRealityModuleModal = ({
           discordKey: discordKey,
           email: emails,
           slackKey: "",
-          telegram: { botToken: telegramBotToken, chatID: telegramChatId },
+          telegram: { botToken: telegramBotToken, chatId: telegramChatId },
         }
         // we trust the notification parameters for discord and telegram are valid
         // user was forced to pass at least an email address to get here

--- a/packages/app/src/views/AddModule/wizards/RealityModule/sections/Monitoring/index.tsx
+++ b/packages/app/src/views/AddModule/wizards/RealityModule/sections/Monitoring/index.tsx
@@ -63,7 +63,7 @@ export interface MonitoringSectionData {
   secretKey: string
   email: string[]
   discordKey: string
-  telegram: { botToken: string; chatID: string }
+  telegram: { botToken: string; chatId: string }
   slackKey: string
 }
 
@@ -74,7 +74,7 @@ const INITIAL_DATA: MonitoringSectionData = {
   discordKey: "",
   telegram: {
     botToken: "",
-    chatID: "",
+    chatId: "",
   },
   slackKey: "",
 }
@@ -136,7 +136,7 @@ export const MonitoringSection: React.FC<SectionProps> = ({
     fieldName: string,
   ) => {
     event.preventDefault()
-    if (["chatID", "botToken"].includes(fieldName)) {
+    if (["chatId", "botToken"].includes(fieldName)) {
       const telegram = { ...monitoringData.telegram }
       const newValues = { ...telegram, [fieldName]: event.target.value }
       setMonitoringData({
@@ -181,16 +181,16 @@ export const MonitoringSection: React.FC<SectionProps> = ({
   }
 
   const isInvalidForm = (): boolean => {
-    const { botToken, chatID } = telegram
+    const { botToken, chatId } = telegram
     if (loading || invalidCredentials) {
       return true
     }
-    if ((botToken === "" && chatID !== "") || (botToken !== "" && chatID === "")) {
+    if ((botToken === "" && chatId !== "") || (botToken !== "" && chatId === "")) {
       return true
     }
     if (
       botToken === "" &&
-      chatID === "" &&
+      chatId === "" &&
       discordKey === "" &&
       slackKey === "" &&
       email.length === 0
@@ -376,8 +376,8 @@ export const MonitoringSection: React.FC<SectionProps> = ({
                     placeholder="123"
                     borderStyle="double"
                     className={classes.input}
-                    value={monitoringData.telegram.chatID}
-                    onChange={(e) => updateForm(e, "chatID")}
+                    value={monitoringData.telegram.chatId}
+                    onChange={(e) => updateForm(e, "chatId")}
                   />
                 </Grid>
               </Grid>

--- a/packages/app/src/views/AddModule/wizards/RealityModule/sections/Review/index.tsx
+++ b/packages/app/src/views/AddModule/wizards/RealityModule/sections/Review/index.tsx
@@ -305,7 +305,7 @@ export const ReviewSection: React.FC<ReviewSectionProps> = ({
                             Bot token: {monitoring.telegram.botToken}
                           </Typography>
                           <Typography className={classes.label}>
-                            Chat ID: {monitoring.telegram.chatID}
+                            Chat ID: {monitoring.telegram.chatId}
                           </Typography>
                         </Grid>
                       )}

--- a/packages/app/src/views/AddModule/wizards/RealityModule/service/monitoring.ts
+++ b/packages/app/src/views/AddModule/wizards/RealityModule/service/monitoring.ts
@@ -40,7 +40,7 @@ export const setUpMonitoring = async (
     (data.slackKey ?? "") === "" &&
     data.email.length === 0 &&
     (data.telegram.botToken ?? "") === "" &&
-    (data.telegram.chatID ?? "")
+    (data.telegram.chatId ?? "")
   ) {
     throw new Error(
       "No notification channel(s) specified. Monitoring will NOT be set up.",


### PR DESCRIPTION
caused failure when setting up notifications,
preventing all notification setup entirely

Tested

Showing a link with `chatId` instead of `chatID`:

https://github.com/OpenZeppelin/defender-client/blob/917eac7a1cff9ddb6c9e64e1d1aa7a4593d53cba/packages/sentinel/src/models/notification.ts#L51

