### PR TITLE
feat(app): warn about + block adding vulnerable Roles v2 / Delay mods

### DIFF
--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -6,6 +6,7 @@ import Header from "./views/Header"
 import { makeStyles } from "@material-ui/core"
 import TransactionBuilder from "./views/TransactionBuilder"
 import zodiacBackground from "./assets/images/zodiac-bg.svg"
+import SecurityBanner from "./components/SecurityBanner"
 
 const useStyles = makeStyles((theme) => ({
   root: {
@@ -26,6 +27,7 @@ const App: React.FC = () => {
   return (
     <div className={classes.root}>
       <div className={classes.background}>
+        <SecurityBanner />
         <Header />
         <AppLayout left={<Panel />}>
           <Views />

--- a/packages/app/src/components/SecurityBanner.tsx
+++ b/packages/app/src/components/SecurityBanner.tsx
@@ -1,0 +1,105 @@
+import React, { useState } from 'react'
+import { makeStyles, Typography } from '@material-ui/core'
+import { useSafeAppsSDK } from '@gnosis.pm/safe-apps-react-sdk'
+import { useRootSelector } from '../store'
+import { getModulesList } from '../store/modules/selectors'
+import { Module, ModuleType } from '../store/modules/models'
+
+const NOTICE_URL = 'https://x.com/zodiaceco/status/2061862711206502902'
+const ZODIAC_APP_ORIGIN = 'https://app.zodiac.eco'
+
+// Module types affected by the fallback-handler vulnerability. Roles Modifier v1
+// is not affected.
+const AFFECTED_TYPES = [ModuleType.ROLES_V2, ModuleType.DELAY]
+
+const flatten = (modules: Module[]): Module[] =>
+  modules.flatMap((module) => [module, ...flatten(module.subModules ?? [])])
+
+const useStyles = makeStyles((theme) => ({
+  banner: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: theme.spacing(2),
+    padding: theme.spacing(1.5, 2),
+    marginBottom: theme.spacing(2),
+    background: '#fbbf24',
+    color: '#451a03',
+    borderRadius: 4,
+    border: '1px solid rgba(69, 26, 3, 0.35)',
+  },
+  text: {
+    flex: 1,
+  },
+  link: {
+    color: '#451a03',
+    fontWeight: 600,
+    textDecoration: 'underline',
+  },
+  dismiss: {
+    background: 'none',
+    border: 'none',
+    color: '#451a03',
+    cursor: 'pointer',
+    fontSize: 18,
+    lineHeight: 1,
+    padding: theme.spacing(0.5),
+  },
+}))
+
+/**
+ * Warns when the connected Safe has a Zodiac module affected by the Roles v2 /
+ * Delay v1.1.0 fallback-handler vulnerability, with a link to the remediation
+ * tool. Detected from the modules already loaded into the store — including
+ * nested sub-modules — so no external call is needed. Roles Modifier v1 is
+ * unaffected and never triggers the banner.
+ */
+export const SecurityBanner: React.FC = () => {
+  const classes = useStyles()
+  const { safe } = useSafeAppsSDK()
+  const modules = useRootSelector(getModulesList)
+  const [dismissed, setDismissed] = useState(false)
+
+  const affected = flatten(modules).some((module) =>
+    AFFECTED_TYPES.includes(module.type),
+  )
+  if (!affected || dismissed) return null
+
+  const checkerUrl = `${ZODIAC_APP_ORIGIN}/public/fallback-handler?address=${safe.safeAddress}&chainId=${safe.chainId}`
+
+  return (
+    <div role='alert' className={classes.banner}>
+      <Typography variant='body2' className={classes.text}>
+        <strong>Security update:</strong> this Safe has a Zodiac Roles Modifier
+        v2 and/or Delay Modifier affected by a known vulnerability in specific
+        setups.{' '}
+        <a
+          href={checkerUrl}
+          target='_blank'
+          rel='noopener noreferrer'
+          className={classes.link}
+        >
+          Review &amp; remediate
+        </a>
+        {' · '}
+        <a
+          href={NOTICE_URL}
+          target='_blank'
+          rel='noopener noreferrer'
+          className={classes.link}
+        >
+          Read the full notice
+        </a>
+      </Typography>
+      <button
+        type='button'
+        aria-label='Dismiss'
+        className={classes.dismiss}
+        onClick={() => setDismissed(true)}
+      >
+        ✕
+      </button>
+    </div>
+  )
+}
+
+export default SecurityBanner

--- a/packages/app/src/views/AddModule/ModuleButton.tsx
+++ b/packages/app/src/views/AddModule/ModuleButton.tsx
@@ -10,6 +10,9 @@ interface ModuleButtonProps extends BadgeIconProps {
   description: string
   available: boolean
   deprecated?: boolean
+  // Temporarily blocks adding this module (shown greyed-out and non-clickable),
+  // e.g. while a security issue affecting it is being addressed.
+  disabled?: boolean
   className?: string
   onClick(): void
 }
@@ -27,6 +30,13 @@ const useStyles = makeStyles((theme) => ({
       background: 'rgba(217, 212, 173, 0.15)',
     },
   },
+  disabled: {
+    opacity: 0.45,
+    cursor: 'not-allowed',
+    '&:hover': {
+      background: 'transparent',
+    },
+  },
   badgeIcon: {
     background: colors.sepia[100],
     marginBottom: theme.spacing(1),
@@ -42,6 +52,7 @@ export const ModuleButton = ({
   icon,
   available,
   deprecated,
+  disabled,
   className,
   onClick,
 }: ModuleButtonProps) => {
@@ -52,8 +63,8 @@ export const ModuleButton = ({
   return (
     <ZodiacPaper
       borderStyle='double'
-      className={classNames(classes.root, className)}
-      onClick={onClick}
+      className={classNames(classes.root, disabled && classes.disabled, className)}
+      onClick={disabled ? undefined : onClick}
       placeholder={undefined}
       onPointerEnterCapture={undefined}
       onPointerLeaveCapture={undefined}
@@ -62,7 +73,11 @@ export const ModuleButton = ({
       <Typography variant='h6' className={classes.title}>
         {title}
       </Typography>
-      {deprecated && <Tag>Deprecated</Tag>}
+      {disabled ? (
+        <Tag>Temporarily disabled</Tag>
+      ) : (
+        deprecated && <Tag>Deprecated</Tag>
+      )}
       <Typography variant='body2' align='center'>
         {description}
       </Typography>

--- a/packages/app/src/views/AddModule/index.tsx
+++ b/packages/app/src/views/AddModule/index.tsx
@@ -120,6 +120,8 @@ export const AddModulesView = () => {
           icon='delay'
           onClick={() => setModule(ModuleType.DELAY)}
           available={!!ContractAddresses[KnownContracts.DELAY]}
+          // Temporarily disabled while the Delay v1.1.0 security issue is addressed.
+          disabled
         />
 
         <ModuleButton
@@ -136,6 +138,9 @@ export const AddModulesView = () => {
           icon='roles'
           onClick={() => setModule(ModuleType.ROLES_V2)}
           available={!!ContractAddresses[KnownContracts.ROLES_V2]}
+          // Temporarily disabled while the Roles v2 security issue is addressed.
+          // Roles Modifier v1 (below) is unaffected and stays enabled.
+          disabled
         />
 
         <ModuleButton


### PR DESCRIPTION
## What

Temporary mitigation in the Zodiac Safe app for the **Roles Modifier v2 / Delay Modifier v1.1.0** fallback-handler vulnerability:

1. **Security banner** — when the connected Safe has a Roles v2 or Delay module, a dismissable warning appears at the top linking to the remediation tool and the full notice.
2. **Add-module flow** — the **Delay Modifier** and **Roles Modifier** (v2) buttons are disabled (greyed-out, non-clickable, labelled "Temporarily disabled").

**Roles Modifier v1** is unaffected — it stays fully enabled and never triggers the banner. All other module types are untouched.

## How

- `components/SecurityBanner.tsx` — detects a vulnerable module **locally** from the modules already loaded in the store (recursively, including nested sub-modules), so no external request is needed. Links to `app.zodiac.eco/public/fallback-handler?address=<safe>&chainId=<chainId>`.
- `views/AddModule/ModuleButton.tsx` — adds a `disabled` mode (greyed/non-clickable + tag).
- `views/AddModule/index.tsx` — sets `disabled` on the Delay and Roles v2 buttons.

## Notes

- The banner warns whenever a vulnerable-*type* module is present (even if that specific instance is already remediated); the linked checker gives the precise status. This keeps the app self-contained (no dependency on the public API's CORS).
- Typecheck clean. Best verified by loading the app against a Safe that has a Roles v2 / Delay module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)